### PR TITLE
use https url and escape urls in template

### DIFF
--- a/badge.html
+++ b/badge.html
@@ -1,22 +1,22 @@
 <div class="npm-scb-wrap">
   <div class="npm-scb-inner">
-    <a target="_blank" href="{{urls.song}}">
-      <img class="npm-scb-icon" src="{{icon}}">
-      <img class="npm-scb-artwork" src="{{artwork}}">
+    <a target="_blank" href="{{!urls.song}}">
+      <img class="npm-scb-icon" src="{{!icon}}">
+      <img class="npm-scb-artwork" src="{{!artwork}}">
     </a>
     <div class="npm-scb-info">
-      <a target="_blank" href="{{urls.song}}">
+      <a target="_blank" href="{{!urls.song}}">
         <p class="npm-scb-title">{{title}}</p>
       </a>
-      <a target="_blank" href="{{urls.artist}}">
+      <a target="_blank" href="{{!urls.artist}}">
         <p class="npm-scb-artist">{{artist}}</p>
       </a>
     </div>
   </div>
   <div class="npm-scb-now-playing">
     Now Playing:
-    <a href="{{urls.song}}">{{title}}</a>
+    <a href="{{!urls.song}}">{{title}}</a>
     by
-    <a href="{{urls.artist}}">{{artist}}</a>
+    <a href="{{!urls.artist}}">{{artist}}</a>
   </div>
 </div>

--- a/badge.html
+++ b/badge.html
@@ -6,17 +6,17 @@
     </a>
     <div class="npm-scb-info">
       <a target="_blank" href="{{!urls.song}}">
-        <p class="npm-scb-title">{{title}}</p>
+        <p class="npm-scb-title">{{!title}}</p>
       </a>
       <a target="_blank" href="{{!urls.artist}}">
-        <p class="npm-scb-artist">{{artist}}</p>
+        <p class="npm-scb-artist">{{!artist}}</p>
       </a>
     </div>
   </div>
   <div class="npm-scb-now-playing">
     Now Playing:
-    <a href="{{!urls.song}}">{{title}}</a>
+    <a href="{{!urls.song}}">{{!title}}</a>
     by
-    <a href="{{!urls.artist}}">{{artist}}</a>
+    <a href="{{!urls.artist}}">{{!artist}}</a>
   </div>
 </div>

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ var insert = require('insert-css')
 var fs = require('fs')
 
 var icons = {
-    black: 'http://developers.soundcloud.com/assets/logo_black.png'
-  , white: 'http://developers.soundcloud.com/assets/logo_white.png'
+    black: 'https://developers.soundcloud.com/assets/logo_black.png'
+  , white: 'https://developers.soundcloud.com/assets/logo_white.png'
 }
 
 module.exports = badge


### PR DESCRIPTION
This allows it to work in GH pages, otherwise the image links are showing errors. eg:
http://mattdesl.github.io/spins/ (uses this PR)
