### PR TITLE
bump resolve to include https

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "dependencies": {
     "brfs": "~0.0.8",
-    "soundcloud-resolve": "~0.0.0",
     "google-fonts": "~0.0.0",
+    "insert-css": "~0.0.0",
     "minstache": "~1.1.0",
-    "insert-css": "~0.0.0"
+    "soundcloud-resolve": "^1.0.2"
   },
   "browserify": {
     "transform": "brfs"


### PR DESCRIPTION
I ran `npm install soundcloud-resolve@latest --save` for this PR to get the https stuff. :smile:
